### PR TITLE
update catalog extra definitions in manifest

### DIFF
--- a/lib/getManifest.js
+++ b/lib/getManifest.js
@@ -17,8 +17,8 @@ function generateArrayOfYears() {
 const years = generateArrayOfYears();
 
 async function getManifest(language = DEFAULT_LANGUAGE) {
-  const genres_movie = await getGenreList(language, "movie");
-  const genres_series = await getGenreList(language, "series");
+  const genres_movie = await getGenreList(language, "movie").then(genres => genres.map((el) => el.name).sort());
+  const genres_series = await getGenreList(language, "series").then(genres => genres.map((el) => el.name).sort());
   const descriptionSuffix = language && language !== DEFAULT_LANGUAGE ? ` with ${language} language.` : ".";
 
   return {
@@ -41,43 +41,43 @@ async function getManifest(language = DEFAULT_LANGUAGE) {
         type: "movie",
         id: "movie.top",
         name: "TMDB - Top",
-        extraSupported: ["search", "genre", "skip"],
-        genres: genres_movie.map((el) => {return el.name}).sort(),
+        extra: [
+          { name: "genre", options: genres_movie }, { name: "skip" }, { name: "search" }
+        ],
+        genres: genres_movie,
+        extraSupported: ["genre", "skip", "search"],
       },
       {
         type: "movie",
         id: "movie.year",
         name: "TMDB - By Year",
+        extra: [
+          { name: "genre", options: years, isRequired: true }, { name: "skip" }
+        ],
+        genres: years,
         extraSupported: ["genre", "skip"],
         extraRequired: ["genre"],
-        extra: [
-          {
-            name: "genre",
-            options: years,
-            isRequired: true,
-          },
-        ],
       },
       {
         type: "series",
         id: "series.top",
         name: "TMDB - Top",
-        extraSupported: ["search", "genre", "skip"],
-        genres: genres_series.map((el) => {return el.name}).sort(),
+        extra: [
+          { name: "genre", options: genres_series }, { name: "skip" }, { name: "search" }
+        ],
+        genres: genres_series,
+        extraSupported: ["genre", "skip", "search"],
       },
       {
         type: "series",
         id: "series.year",
         name: "TMDB - By Year",
+        extra: [
+          { name: "genre", options: years, isRequired: true }, { name: "skip" }
+        ],
+        genres: years,
         extraSupported: ["genre", "skip"],
         extraRequired: ["genre"],
-        extra: [
-          {
-            name: "genre",
-            options: years,
-            isRequired: true,
-          },
-        ],
       },
     ],
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmdb-addon",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Metadata provided by TMDB",
   "main": "server.js",
   "dependencies": {


### PR DESCRIPTION
[`extra`](https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/manifest.md#extra-properties) is the new way to define catalog params and should be consistent through the catalogs