### PR TITLE
fix(rating): handle case when rating cannot fetched from cinemeta

### DIFF
--- a/addon/lib/getMeta.js
+++ b/addon/lib/getMeta.js
@@ -17,7 +17,9 @@ async function getMeta(type, language, tmdbId, rpdbkey) {
     const meta = await moviedb
       .movieInfo({id: tmdbId, language, append_to_response: "videos,credits",})
       .then(async (res) => {
-        const imdbRating = res.imdb_id ? await getImdbRating(res.imdb_id, type) : res.vote_average.toFixed(1);
+        const imdbRating = res.imdb_id
+          ? await getImdbRating(res.imdb_id, type) ?? res.vote_average.toString()
+          : res.vote_average.toString();
         const resp = {
           imdb_id: res.imdb_id,
           cast: Utils.parseCast(res.credits),
@@ -25,7 +27,7 @@ async function getMeta(type, language, tmdbId, rpdbkey) {
           description: res.overview,
           director: Utils.parseDirector(res.credits),
           genre: Utils.parseGenres(res.genres),
-          imdbRating,
+          imdbRating: imdbRating || "N/A",
           name: res.title,
           released: new Date(res.release_date),
           slug: Utils.parseSlug(type, res.title, res.imdb_id),
@@ -71,14 +73,16 @@ async function getMeta(type, language, tmdbId, rpdbkey) {
     const meta = await moviedb
       .tvInfo({id: tmdbId, language, append_to_response: "videos,credits,external_ids",})
       .then(async (res) => {
-        const imdbRating = res.external_ids.imdb_id ? await getImdbRating(res.external_ids.imdb_id, type) : res.vote_average.toFixed(1);
+        const imdbRating = res.external_ids.imdb_id
+          ? await getImdbRating(res.external_ids.imdb_id, type) ?? res.vote_average.toString()
+          : res.vote_average.toString();
         const runtime = res.episode_run_time?.[0] ?? res.last_episode_to_air?.runtime ?? res.next_episode_to_air?.runtime ?? null;
         const resp = {
           cast: Utils.parseCast(res.credits),
           country: Utils.parseCoutry(res.production_countries),
           description: res.overview,
           genre: Utils.parseGenres(res.genres),
-          imdbRating,
+          imdbRating: imdbRating || "N/A",
           imdb_id: res.external_ids.imdb_id,
           name: res.name,
           poster: await Utils.parsePoster(type, tmdbId, res.poster_path, language, rpdbkey),


### PR DESCRIPTION
I saw many people in reddit complain about metadata not fetched. I also saw the issue. The error code from stremio was `unable to serialize meta because name is not present`. While this might not be the sole issue, this PR tries to fix some of it.

The current implementation of fetching rating doesn't handle cases where cinemeta returns empty string for rating. In that case we return undefined but isn't handled properly. 

The new implementation checks that. and if it is undefined, it tries to use `vote_average` from tmdb and finally fallback to "N/A" if nothing is found. 

**For Daredevil: Born Again**
Current Behavious
```json
"links": [
      {
        "category": "imdb",
        "url": "https://imdb.com/title/tt18923754"
      },
      {
        "name": "Daredevil: Born Again",
        "category": "share",
        "url": "https://www.strem.io/s/tv/daredevil:-born-again-18923754"
      },
```

No, name in links for imdb rating

New Behavious
```json
"genre": [
      "Drama",
      "Crime"
    ],
    "imdbRating": "8.3",
```

```json
"links": [
      {
        "name": "8.3",
        "category": "imdb",
        "url": "https://imdb.com/title/tt18923754"
      },
      {
        "name": "Daredevil: Born Again",
        "category": "share",
        "url": "https://www.strem.io/s/tv/daredevil:-born-again-18923754"
      },
```

You can see rating in links now. 

This does create confusion as this is not the exact rating of series and people might comment that it is showing wrong rating. If we want to exactly show imdb rating, we can just remove vote_average step and implement accordingly.
