### PR TITLE
fix: update Top Posters integration icon

### DIFF
--- a/configure/src/data/integrations.ts
+++ b/configure/src/data/integrations.ts
@@ -21,7 +21,7 @@ export const integrations: Integration[] = [
   {
     id: "topposters",
     name: "Top Posters",
-    icon: "https://api.top-streaming.stream/favicon.ico",
+    icon: "https://api.top-streaming.stream/static/favicon.svg",
     description: "High-quality posters with rating and trend badges. Takes priority over RPDB for posters.",
   },
   {


### PR DESCRIPTION
Small fix to point the Top Posters integration to its working official SVG icon. I didn't find an existing issue for this.