### PR TITLE
fix: translate auth messages to English

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -277,14 +277,14 @@ addon.get("/:catalogChoices?/catalog/:type/:id/:extra?.json", async function (re
         case "trakt.watchlist":
           const traktAccessToken = config.traktAccessToken;
           if (!traktAccessToken) {
-            throw new Error('Trakt access token não fornecido');
+            throw new Error('Trakt access token was not provided');
           }
           metas = await getTraktWatchlist(...args, genre, traktAccessToken);
           break;
         case "trakt.recommendations":
           const traktToken = config.traktAccessToken;
           if (!traktToken) {
-            throw new Error('Trakt access token não fornecido');
+            throw new Error('Trakt access token was not provided');
           }
           metas = await getTraktRecommendations(...args, genre, traktToken);
           break;

--- a/addon/lib/getTraktLists.js
+++ b/addon/lib/getTraktLists.js
@@ -4,7 +4,7 @@ const { getMeta } = require('./getMeta')
 
 async function getTraktWatchlist(type, language, page, genre, accessToken) {
   if (!accessToken) {
-    throw new Error('Access token do Trakt não fornecido')
+    throw new Error('Trakt access token was not provided')
   }
 
   try {
@@ -51,7 +51,7 @@ async function getTraktWatchlist(type, language, page, genre, accessToken) {
 
 async function getTraktRecommendations(type, language, page, genre, accessToken) {
   if (!accessToken) {
-    throw new Error('Access token do Trakt não fornecido')
+    throw new Error('Trakt access token was not provided')
   }
 
   try {

--- a/addon/lib/getTraktSession.js
+++ b/addon/lib/getTraktSession.js
@@ -25,7 +25,7 @@ function getRedirectUri(requestHost = null) {
 
 async function getTraktAuthUrl(requestHost = null) {
   if (!TRAKT_CLIENT_ID) {
-    throw new Error('TRAKT_CLIENT_ID não configurado')
+    throw new Error('TRAKT_CLIENT_ID is not configured')
   }
 
   const redirectUri = getRedirectUri(requestHost)
@@ -38,7 +38,7 @@ async function getTraktAuthUrl(requestHost = null) {
 
 async function getTraktAccessToken(code, redirectUri = null) {
   if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
-    throw new Error('TRAKT_CLIENT_ID ou TRAKT_CLIENT_SECRET não configurados')
+    throw new Error('TRAKT_CLIENT_ID or TRAKT_CLIENT_SECRET is not configured')
   }
 
   // Usa o redirect_uri fornecido ou o padrão
@@ -60,13 +60,13 @@ async function getTraktAccessToken(code, redirectUri = null) {
     return response.data || response
   } catch (err) {
     console.error('Erro ao obter access token do Trakt:', err)
-    return { success: false, error: err.message || 'Erro ao autenticar com Trakt' }
+    return { success: false, error: err.message || 'Failed to authenticate with Trakt' }
   }
 }
 
 async function refreshTraktAccessToken(refreshToken, redirectUri = null) {
   if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
-    throw new Error('TRAKT_CLIENT_ID ou TRAKT_CLIENT_SECRET não configurados')
+    throw new Error('TRAKT_CLIENT_ID or TRAKT_CLIENT_SECRET is not configured')
   }
 
   // Usa o redirect_uri fornecido ou o padrão
@@ -88,7 +88,7 @@ async function refreshTraktAccessToken(refreshToken, redirectUri = null) {
     return response.data || response
   } catch (err) {
     console.error('Erro ao renovar access token do Trakt:', err)
-    return { success: false, error: err.message || 'Erro ao renovar token do Trakt' }
+    return { success: false, error: err.message || 'Failed to refresh Trakt token' }
   }
 }
 

--- a/configure/src/integrations/tmdb.tsx
+++ b/configure/src/integrations/tmdb.tsx
@@ -148,7 +148,7 @@ export default function TMDB() {
       // Verifica se o popup foi bloqueado
       if (!popup || popup.closed || typeof popup.closed === 'undefined') {
         setIsLoading(false);
-        setError('Popup bloqueado. Por favor, permita popups para este site.');
+        setError('Popup blocked. Please allow popups for this site.');
         return;
       }
 

--- a/configure/src/integrations/trakt.tsx
+++ b/configure/src/integrations/trakt.tsx
@@ -17,14 +17,14 @@ export default function Trakt() {
     setError("");
     try {
       if (!code || code.trim() === '') {
-        throw new Error('Código de autorização inválido');
+        throw new Error('Invalid authorization code');
       }
       
       const uuid = crypto.randomUUID();
       const response = await fetch(`/trakt_access_token?code=${encodeURIComponent(code)}&cache_buster=${uuid}`);
       
       if (!response.ok) {
-        let errorMessage = 'Falha ao obter token de acesso';
+        let errorMessage = 'Failed to get access token';
         try {
           const errorData = await response.json();
           errorMessage = errorData.error || errorMessage;
@@ -39,12 +39,12 @@ export default function Trakt() {
       
       // Verifica se a resposta é um JSON com erro
       if (tokenData.error || tokenData.success === false) {
-        throw new Error(tokenData.error || tokenData.status_message || 'Falha ao obter token de acesso');
+        throw new Error(tokenData.error || tokenData.status_message || 'Failed to get access token');
       }
       
       // Valida se o access token não está vazio
       if (!tokenData.access_token || tokenData.access_token.trim() === '') {
-        throw new Error('Token de acesso vazio recebido');
+        throw new Error('Empty access token received');
       }
       
       setTraktAccessToken(tokenData.access_token);
@@ -105,14 +105,14 @@ export default function Trakt() {
       });
 
       toast({
-        title: "Conta Trakt conectada",
-        description: "Sua watchlist e recomendações foram sincronizadas.",
+        title: "Trakt account connected",
+        description: "Your watchlist and recommendations have been synced.",
       });
       
       window.history.replaceState({}, '', window.location.pathname);
     } catch (e) {
       console.error(e);
-      setError(e instanceof Error ? e.message : "Falha ao conectar conta Trakt");
+      setError(e instanceof Error ? e.message : "Failed to connect Trakt account");
     } finally {
       setIsLoading(false);
     }
@@ -139,7 +139,7 @@ export default function Trakt() {
           clearInterval(popupCheckIntervalRef.current);
           popupCheckIntervalRef.current = null;
         }
-        setError(event.data.errorDescription || event.data.error || 'Falha na autenticação');
+        setError(event.data.errorDescription || event.data.error || 'Authentication failed');
         setIsLoading(false);
       }
     };
@@ -168,7 +168,7 @@ export default function Trakt() {
       const response = await fetch(`/trakt_auth_url?cache_buster=${uuid}`);
       
       if (!response.ok) {
-        let errorMessage = 'Falha ao obter URL de autenticação';
+        let errorMessage = 'Failed to get authentication URL';
         try {
           const errorData = await response.json();
           errorMessage = errorData.error || errorMessage;
@@ -183,7 +183,7 @@ export default function Trakt() {
       
       // Valida se a URL não está vazia
       if (!data.authUrl || data.authUrl.trim() === '') {
-        throw new Error('URL de autenticação vazia recebida');
+        throw new Error('Empty authentication URL received');
       }
       
       // O backend já gera a URL de autenticação com o redirect_uri correto (/configure/oauth-callback)
@@ -205,7 +205,7 @@ export default function Trakt() {
       // Verifica se o popup foi bloqueado
       if (!popup || popup.closed || typeof popup.closed === 'undefined') {
         setIsLoading(false);
-        setError('Popup bloqueado. Por favor, permita popups para este site.');
+        setError('Popup blocked. Please allow popups for this site.');
         return;
       }
 
@@ -221,7 +221,7 @@ export default function Trakt() {
       }, 1000);
     } catch (e) {
       console.error(e);
-      setError(e instanceof Error ? e.message : "Falha ao iniciar autenticação Trakt");
+      setError(e instanceof Error ? e.message : "Failed to start Trakt authentication");
       setIsLoading(false);
     }
   };
@@ -234,8 +234,8 @@ export default function Trakt() {
     setCatalogs((prev) => prev.filter((c) => !c.id.startsWith("trakt.")));
 
     toast({
-      title: "Conta Trakt desconectada",
-      description: "Sua conta Trakt foi desconectada com sucesso.",
+      title: "Trakt account disconnected",
+      description: "Your Trakt account has been disconnected successfully.",
     });
   };
 
@@ -253,12 +253,12 @@ export default function Trakt() {
           <div className="flex flex-col items-center space-y-4">
             <Alert>
               <AlertDescription>
-                Você está conectado ao Trakt
+                You are connected to Trakt
               </AlertDescription>
             </Alert>
             <DialogClose asChild>
               <Button variant="destructive" onClick={handleLogout}>
-                Desconectar
+                Disconnect
               </Button>
             </DialogClose>
           </div>
@@ -271,10 +271,10 @@ export default function Trakt() {
             {isLoading ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Conectando ao Trakt...
+                Connecting to Trakt...
               </>
             ) : (
-              'Conectar com Trakt'
+              'Connect with Trakt'
             )}
           </Button>
         )}

--- a/configure/src/pages/OAuthCallback.tsx
+++ b/configure/src/pages/OAuthCallback.tsx
@@ -45,7 +45,7 @@ const OAuthCallback = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mb-4"></div>
-        <p className="text-lg text-gray-600">Processando autenticação...</p>
+        <p className="text-lg text-gray-600">Processing authentication...</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Small cleanup to translate auth-related messages from Portuguese to English for consistency with the rest of the UI, including backend Trakt errors that can surface in the configuration flow.