### PR TITLE
fix: improve Trakt OAuth local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ FANART_API=your_fanart_api_key_here
 # TMDB_API is Optional - Users can provide their own TMDB API key via the web interface
 # TMDB_API=your_tmdb_api_key_here 
 
+# Trakt OAuth integration (optional)
+TRAKT_CLIENT_ID=your_trakt_client_id_here
+TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
+
 HOST_NAME=http://localhost:1337
 
 # Server settings

--- a/addon/lib/getTraktSession.js
+++ b/addon/lib/getTraktSession.js
@@ -19,7 +19,7 @@ function getRedirectUri(requestHost = null) {
   }
   
   // Fallback para variável de ambiente ou padrão
-  const baseUrl = process.env.HOST_NAME || 'http://localhost:3000'
+  const baseUrl = process.env.HOST_NAME || 'http://localhost:1337'
   return process.env.TRAKT_REDIRECT_URI || `${baseUrl}/configure/oauth-callback`
 }
 
@@ -93,4 +93,3 @@ async function refreshTraktAccessToken(refreshToken, redirectUri = null) {
 }
 
 module.exports = { getTraktAuthUrl, getTraktAccessToken, refreshTraktAccessToken }
-

--- a/addon/server.js
+++ b/addon/server.js
@@ -15,5 +15,5 @@ process.on('uncaughtException', (error) => {
 
 addon.listen(PORT, function () {
   console.log(`Addon active on port ${PORT}.`);
-  console.log(`http://127.0.0.1:${PORT}/`);
+  console.log(`http://localhost:${PORT}/`);
 });


### PR DESCRIPTION
Adds the missing Trakt OAuth env vars to the example config and aligns the local callback URL with the backend dev port. It also logs localhost instead of 127.0.0.1 so users open the configure page on the same origin used by the Trakt OAuth callback.