### PR TITLE
Fix: catalog preview performance issues

### DIFF
--- a/addon/lib/getCatalog.js
+++ b/addon/lib/getCatalog.js
@@ -2,9 +2,8 @@ require("dotenv").config();
 const { getTmdbClient } = require("../utils/getTmdbClient");
 const { getGenreList } = require("./getGenreList");
 const { getLanguages } = require("./getLanguages");
-const { parseMedia } = require("../utils/parseProps");
+const { getCatalogPreview } = require("./getCatalogPreview");
 const { fetchMDBListItems, parseMDBListItems } = require("../utils/mdbList");
-const { getMeta } = require("./getMeta");
 const { isMovieReleasedInRegion, isMovieReleasedDigitally } = require("./releaseFilter");
 const { rateLimitedMapFiltered } = require("../utils/rateLimiter");
 const CATALOG_TYPES = require("../static/catalog-types.json");
@@ -37,18 +36,9 @@ async function getCatalog(type, language, page, id, genre, config) {
   async function fetchAndFilter(params, regionForReleaseCheck) {
     const res = await fetchFunction(params);
 
-    // Use rate-limited fetching to prevent 429 errors
     let metas = await rateLimitedMapFiltered(
       res.results,
-      async (item) => {
-        try {
-          const result = await getMeta(type, language, item.id, config);
-          return result.meta;
-        } catch (err) {
-          console.error(`Error fetching metadata for ${item.id}:`, err.message);
-          return null;
-        }
-      },
+      item => getCatalogPreview(moviedb, item, type, language, genreList, config),
       { batchSize: 5, delayMs: 200 }
     );
 

--- a/addon/lib/getCatalogPreview.js
+++ b/addon/lib/getCatalogPreview.js
@@ -1,0 +1,48 @@
+const Utils = require("../utils/parseProps");
+
+async function getCatalogPreview(moviedb, item, type, language, genreList, config = {}) {
+  const preview = {
+    ...Utils.parseMedia(item, type, genreList),
+    poster: await Utils.parseMediaImage(type, item.id, item.poster_path, language,
+      config.rpdbkey, "poster", config.rpdbMediaTypes,
+      config.topposterskey, config.toppostersConfig, "w342")
+  };
+
+  try {
+    const details = type === "movie"
+      ? await moviedb.movieInfo({ id: item.id, language, append_to_response: "credits,external_ids" })
+      : await moviedb.tvInfo({ id: item.id, language, append_to_response: "credits,external_ids" });
+    const credits = details.credits || { cast: [], crew: [] };
+    const castCount = config.castCount !== undefined && Number.isFinite(Number(config.castCount))
+      ? Number(config.castCount)
+      : undefined;
+    const imdbId = details.imdb_id || details.external_ids?.imdb_id;
+    const runtime = type === "movie"
+      ? details.runtime
+      : details.episode_run_time?.[0] ?? details.last_episode_to_air?.runtime ?? details.next_episode_to_air?.runtime;
+
+    return {
+      ...preview,
+      id: ((config.returnImdbId === true || config.returnImdbId === "true") && imdbId)
+        ? imdbId
+        : preview.id,
+      releaseInfo: type === "movie"
+        ? preview.releaseInfo
+        : Utils.parseYear(details.status, item.first_air_date, details.last_air_date),
+      runtime: Utils.parseRunTime(runtime),
+      ...(type === "movie"
+        ? { director: Utils.parseDirector(credits), writer: Utils.parseWriter(credits) }
+        : { writer: Utils.parseCreatedBy(details.created_by || []) }),
+      links: [
+        ...(imdbId ? [Utils.parseImdbLink(preview.imdbRating, imdbId)] : []),
+        ...Utils.parseCreditsLink(credits, castCount)
+      ],
+      app_extras: { cast: Utils.parseCast(credits, castCount) }
+    };
+  } catch (error) {
+    console.warn(`Error enriching catalog metadata for ${item.id}:`, error.message);
+    return preview;
+  }
+}
+
+module.exports = { getCatalogPreview };

--- a/addon/lib/getTrending.js
+++ b/addon/lib/getTrending.js
@@ -1,11 +1,13 @@
 require("dotenv").config();
 const { getTmdbClient } = require("../utils/getTmdbClient");
-const { getMeta } = require("./getMeta");
+const { getGenreList } = require("./getGenreList");
+const { getCatalogPreview } = require("./getCatalogPreview");
 const { isMovieReleasedInRegion, isMovieReleasedDigitally } = require("./releaseFilter");
 const { rateLimitedMapFiltered } = require("../utils/rateLimiter");
 
 async function getTrending(type, language, page, genre, config) {
   const moviedb = getTmdbClient(config);
+  const genreList = await getGenreList(language, type, config);
   const media_type = type === "series" ? "tv" : type;
 
   const isStrictMode = (config.strictRegionFilter === "true" || config.strictRegionFilter === true);
@@ -27,18 +29,9 @@ async function getTrending(type, language, page, genre, config) {
 
     const res = await moviedb.trending(parameters);
 
-    // Use rate-limited fetching to prevent 429 errors
     let metas = await rateLimitedMapFiltered(
       res.results,
-      async (item) => {
-        try {
-          const result = await getMeta(type, language, item.id, config);
-          return result.meta;
-        } catch (err) {
-          console.error(`Error fetching metadata for ${item.id}:`, err.message);
-          return null;
-        }
-      },
+      item => getCatalogPreview(moviedb, item, type, language, genreList, config),
       { batchSize: 5, delayMs: 200 }
     );
 

--- a/addon/utils/parseProps.js
+++ b/addon/utils/parseProps.js
@@ -212,9 +212,9 @@ function parseConfig(catalogChoices) {
 }
 
 
-async function parseMediaImage(type, id, imagePath, language, rpdbkey, mediaType = "poster", rpdbMediaTypes = null, topposterskey = null, toppostersConfig = null) {
+async function parseMediaImage(type, id, imagePath, language, rpdbkey, mediaType = "poster", rpdbMediaTypes = null, topposterskey = null, toppostersConfig = null, tmdbPosterSize = "w500") {
   // Determina o tamanho da imagem do TMDB baseado no tipo de mídia
-  const tmdbSize = mediaType === "backdrop" || mediaType === "logo" ? "original" : "w500";
+  const tmdbSize = mediaType === "backdrop" || mediaType === "logo" ? "original" : tmdbPosterSize;
   const tmdbImage = `https://image.tmdb.org/t/p/${tmdbSize}${imagePath}`;
 
   // Verify TopPosters
@@ -259,16 +259,18 @@ function parseMedia(el, type, genreList = []) {
   const genres = Array.isArray(el.genre_ids)
     ? el.genre_ids.map(genre => genreList.find((x) => x.id === genre)?.name || 'Unknown')
     : [];
+  const year = type === 'movie' ? el.release_date?.substr(0, 4) : el.first_air_date?.substr(0, 4);
 
   return {
     id: `tmdb:${el.id}`,
     name: type === 'movie' ? el.title : el.name,
     genre: genres,
-    poster: `https://image.tmdb.org/t/p/w500${el.poster_path}`,
-    background: `https://image.tmdb.org/t/p/original${el.backdrop_path}`,
+    poster: `https://image.tmdb.org/t/p/w342${el.poster_path}`,
+    background: `https://image.tmdb.org/t/p/w1280${el.backdrop_path}`,
     posterShape: "regular",
     imdbRating: el.vote_average ? el.vote_average.toFixed(1) : 'N/A',
-    year: type === 'movie' ? (el.release_date ? el.release_date.substr(0, 4) : "") : (el.first_air_date ? el.first_air_date.substr(0, 4) : ""),
+    year: year || "",
+    releaseInfo: year || "",
     type: type === 'movie' ? type : 'series',
     description: el.overview,
   };


### PR DESCRIPTION
I also ran into the issue #102 , which made using this wonderful addon a pain on my TV.
This patch adjusts how the catalog previews are fetched, resulting in much better performance and thus smooth navigating in the TV app.

I've tested it on phone, web and LG TV, and could not find any regression, just good performance :)

Resolves #102 