### PR TITLE
fix: use Hulu episode order for Futurama

### DIFF
--- a/addon/static/diferentOrder.json
+++ b/addon/static/diferentOrder.json
@@ -289,5 +289,10 @@
     "tmdbId": "117465",
     "episodeGroupId": "696cdde23780dd46ca7f9f47",
     "name": "Hell's Paradise"
+  },
+  {
+    "tmdbId": "615",
+    "episodeGroupId": "68d05adeb6c8bf2bb6cec5cf",
+    "name": "Futurama"
   }
 ]


### PR DESCRIPTION
## Summary

Add Futurama to the alternate episode-order mapping using the TMDB Hulu Order episode group.

Fixes #2252.

## Problem

The TMDB Addon currently uses the default TMDB production-season numbering for Futurama while assigning IMDb-based Stremio video IDs. Cinemeta uses Hulu/broadcast numbering for the same IMDb series.

This causes the same video ID to represent different episodes. For example:

- Cinemeta: `tt0149460:11:1` = "The Impossible Stream"
- TMDB Addon: `tt0149460:11:1` = "Beef", which is broadcast `S14E01`

Stremio can therefore combine metadata and streams belonging to different episodes.

## Fix

Add TMDB TV ID `615` to `addon/static/diferentOrder.json` using episode group `68d05adeb6c8bf2bb6cec5cf`.

This is the TMDB Hulu Order group, containing all 168 episodes across broadcast seasons 1–14.

## Verification

Representative mappings through the existing `getEpisodes` alternate-order path:

- "The Impossible Stream" → `tt0149460:11:1`
- "Beef" → `tt0149460:14:1`
- "Catfish Hunter" → `tt0149460:14:2`

Validation performed:

- JSON structure and mapping uniqueness check: passed
- `npm run lint`: passed with four existing warnings and no errors
- `npm run build`: passed
- `npm test`: unavailable because the repository does not define a `test` script
- Targeted `getEpisodes` mapping check: passed